### PR TITLE
fix: resolve Hugo build error and update deprecated config keys

### DIFF
--- a/config/_default/languages.yaml
+++ b/config/_default/languages.yaml
@@ -4,7 +4,7 @@
 
 # Default language
 en:
-  languageCode: en-us
+  locale: en-us
   # Uncomment for multi-lingual sites, and move English content into `en` sub-folder.
   #contentDir: content/en
 

--- a/config/_default/module.yaml
+++ b/config/_default/module.yaml
@@ -13,13 +13,13 @@ imports:
 mounts:
   - source: hugo-blox/blox/community
     target: layouts/_partials/blox/community/
-    includeFiles: '**.html'
+    files: '**.html'
   - source: hugo-blox/blox/all-access
     target: layouts/_partials/blox/
-    includeFiles: '**.html'
+    files: '**.html'
   - source: hugo-blox/blox
     target: assets/dist/community/blox/
-    includeFiles: '**.css'
+    files: '**.css'
   - source: layouts
     target: layouts
   - source: assets

--- a/content/post/_index.md
+++ b/content/post/_index.md
@@ -4,9 +4,6 @@ view: article-grid
 cms_exclude: true
 #url: post
 
-# View
-view: card
-
 # Optional cover image (relative to `assets/media/` folder).
 image:
   caption: ''


### PR DESCRIPTION
- Remove duplicate 'view' key in content/post/_index.md (kept article-grid)
- Update languages.yaml: replace 'languageCode' with 'locale'
- Update module.yaml: replace 'includeFiles' with 'files' in mounts

The build now succeeds without the 'mapping key already defined' error. Remaining warnings about includeFiles and .Site.LanguageCode originate from imported HugoBlox modules and theme templates.